### PR TITLE
Usare due oggetti diversi per piva e cf

### DIFF
--- a/api.inad.gov.it-openapi.yaml
+++ b/api.inad.gov.it-openapi.yaml
@@ -86,19 +86,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Errore'
-  /{cf}:
+  /domicilio/{identificativo}:
     get:
       tags:
         - API ESTRAZIONI PUNTUALI
       description: Consente di ottenere il domicilio digitale corrispondente al codice fiscale al momento della consultazione e, in caso di domicilio digitale eletto in qualità di Professionista, anche l'attività professionale esercitata.
       operationId: recuperoDomicilioDigitale
       parameters:
-        - name: cf
+        - name: identificativo
           in: path
           description: CF/PIVA del Domicilio per il quale si effettua la ricerca
           required: true
           schema:
-            $ref: '#/components/schemas/CodiceFiscale'
+            $ref: '#/components/schemas/CodiceIdentificativo'
           example: RRANGL74M28R701V
       responses:
         '200':
@@ -143,19 +143,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Errore'
-  /verifica/{cf}:
+  /verifica/{identificativo}:
     get:
       tags:
         - API ESTRAZIONI PUNTUALI
       description: Fornito in input il domicilio digitale (indirizzo PEC), codice fiscale e data, il servizio consente di verificare se, alla data indicata, il domicilio digitale era associato al codice fiscale indicato.
       operationId: verificaDomicilioDigitale
       parameters:
-        - name: cf
+        - name: identificativo
           in: path
           description: CF/PIVA del Domicilio per il quale si effettua la ricerca
           required: true
           schema:
-            $ref: '#/components/schemas/CodiceFiscale'
+            $ref: '#/components/schemas/CodiceIdentificativo'
           example: RRANGL74M28R701V
         - name: string
           in: query
@@ -342,10 +342,24 @@ paths:
                 $ref: '#/components/schemas/Errore'
 components:
   schemas:
+    CodiceIdentificativo:
+      description: |-
+        L'identificato del domicilio digitale è uno dei due
+        possibili codici.
+      anyOf:
+        - $ref: PartitaIVA
+        - $ref: CodiceFiscale
+    PartitaIVA:
+      type: string
+      description: La partita IVA
+      pattern: '[0-9]{11}'
+      example: 12345678901
     CodiceFiscale:
       pattern: ^([0-9]{11})|([A-Za-z]{6}[0-9]{2}[A-Za-z]{1}[0-9]{2}[A-Za-z]{1}[0-9]{3}[A-Za-z]{1})$
       type: string
-      description: Codice Fiscale/Partita IVA relativa al Domicilio Digitale
+      description: |-
+        Codice Fiscale relativo al Domicilio Digitale
+        La sintassi include i valori dei codici numerici provvisori.
       example: RRANGL74M28R701V
     DomicilioDigitale:
       pattern: ^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$


### PR DESCRIPTION
Un paio di suggerimenti:

- partita iva e codice fiscale sono concetti diversi.  Per rendere l'API evolvibile separerei i due tipi. Non dovrebbe cambiare nulla a livello pratico, ma un domani si potrebbe aggiungere un altro codice (eg. codice anpr...) in modo pulito
- alcuni tool si incartano se c'è un path `/{subito}` perché potrebbe "nascondere"  altri endpoint... sempre meglio definire prima un path.

Per ora questi + il validatore https://italia.github.io/api-oas-checker/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fvintra73%2FINAD_API_estrazione%2Fmain%2Fapi.inad.gov.it-openapi.yaml
