### PR TITLE
Le partite iva non sono ammesse e fix tecnico

### DIFF
--- a/api.inad.gov.it-openapi.yaml
+++ b/api.inad.gov.it-openapi.yaml
@@ -86,16 +86,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Errore'
-  /{cf}:
+  /domicilio/{codice_fiscale}:
     get:
       tags:
         - API ESTRAZIONI PUNTUALI
       description: Consente di ottenere il domicilio digitale corrispondente al codice fiscale al momento della consultazione e, in caso di domicilio digitale eletto in qualità di Professionista, anche l'attività professionale esercitata.
       operationId: recuperoDomicilioDigitale
       parameters:
-        - name: cf
+        - name: codice_fiscale
           in: path
-          description: CF/PIVA del Domicilio per il quale si effettua la ricerca
+          description: CF del Domicilio per il quale si effettua la ricerca
           required: true
           schema:
             $ref: '#/components/schemas/CodiceFiscale'


### PR DESCRIPTION
- rimosso riferimento a p.iva come da suggerimento in #17 
- prefissato /domicilio per evitare che /{cf} nasconda altri endpoint
- usato nome ontopia codice_fiscale